### PR TITLE
Revert "3-5 テスト失敗時にmasterブランチへマージ不可にする"

### DIFF
--- a/tests/Feature/ArticleControllerTest.php
+++ b/tests/Feature/ArticleControllerTest.php
@@ -15,7 +15,7 @@ class ArticleControllerTest extends TestCase
     {
         $response = $this->get(route('articles.index'));
 
-        $response->assertStatus(400)
+        $response->assertStatus(200)
             ->assertViewIs('articles.index');
     }
 


### PR DESCRIPTION
This reverts commit c22285ae7aa8831139bbab4bdaedc20de92dcda5.